### PR TITLE
Change frontend-maven-plugin to be run on deploy phase

### DIFF
--- a/directory/pom.xml
+++ b/directory/pom.xml
@@ -68,6 +68,7 @@
                         <goals>
                             <goal>install-node-and-npm</goal>
                         </goals>
+                        <phase>deploy</phase>
                         <configuration>
                             <nodeVersion>v5.1.0</nodeVersion>
                             <npmVersion>3.3.12</npmVersion>
@@ -79,6 +80,7 @@
                         <goals>
                             <goal>npm</goal>
                         </goals>
+                        <phase>deploy</phase>
                     </execution>
 
                     <execution>
@@ -86,6 +88,7 @@
                         <goals>
                             <goal>bower</goal>
                         </goals>
+                        <phase>deploy</phase>
                     </execution>
 
                     <execution>
@@ -93,7 +96,7 @@
                         <goals>
                             <goal>gulp</goal>
                         </goals>
-
+                        <phase>deploy</phase>
                         <!-- the default phase is "generate-resources" -->
 
                         <configuration>
@@ -106,6 +109,7 @@
                         <goals>
                             <goal>gulp</goal>
                         </goals>
+                        <phase>deploy</phase>
                         <configuration>
                             <arguments>war</arguments>
                         </configuration>


### PR DESCRIPTION
Running frontend-maven-plugin on deploy phase,
allows to run verify (all other previous steps) without
starting this plugin. Otherwise verify step will fail
if you don't have bower/npm installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/charts/388)
<!-- Reviewable:end -->
