### PR TITLE
Revert "Update documentation for webcomponents-api (#428)"

### DIFF
--- a/documentation/webcomponents-api/charts-getting-started.asciidoc
+++ b/documentation/webcomponents-api/charts-getting-started.asciidoc
@@ -227,20 +227,11 @@ Those files will mimic our REST service to fetch the weather data.
 Next, we create a new web component named `weather-chart` that wraps the Charts component and makes REST calls to fetch the data.
 First, let us do it so that it only wraps the `vaadin-line-chart` component.
 
-First, create a new file [filename]#weather-chart.html# and add the following:
-
-[source, html]
-----
-<link rel="import" href="bower_components/polymer/polymer-element.html">
-<link rel="import" href="bower_components/vaadin-charts/vaadin-line-chart.html">
-----
-
-These are the dependencies required for our new web-component.
-
-Then, let us add the component declaration:
+You can make it as follows:
 
 [source,html]
 ----
+<weather-chart></weather-chart>
 <dom-module id="weather-chart">
   <template>
     <vaadin-line-chart>
@@ -255,31 +246,17 @@ Then, let us add the component declaration:
       </data-series>
     </vaadin-line-chart>
   </template>
-    class WeatherChart extends Polymer.Element {
-      static get is() { return 'weather-chart' }
-    }
-
-    customElements.define(WeatherChart.is, WeatherChart);
+  <script>
+    Polymer({
+      is: 'weather-chart'
+    });
+  </script>
 </dom-module>
-----
-
-Then, at [filename]#index.html# we should import our newly created component, so let us add it inside `<head>`:
-
-[source,html]
-----
-<link rel="import" href="weather-chart.html">
-----
-
-Then, add a `<weather-chart>` element after `<vaadin-line-chart>`:
-
-[source, html]
-----
-<weather-chart></weather-chart>
 ----
 
 Next, we want to call the REST service to fetch the data and bind that to the chart.
 We use the `iron-ajax` component to make the request.
-Back to [filename]#weather-chart.html#, add the following inside the `<template>` element next to the `<vaadin-line-chart>`.
+Add the following inside the `<template>` element next to the `<vaadin-line-chart>`.
 
 [source,html]
 ----
@@ -298,22 +275,17 @@ These can be done by modifying the [classname]#Polymer# object in a `<script>` e
 [source,html]
 ----
 <script>
-  class WeatherChart extends Polymer.Element {
-    static get is() { return 'weather-chart' }
-
-    static get properties() {
-      return {
-        temperatureData: Object,
-      }
+  Polymer({
+    is: 'weather-chart',
+    properties: {
+      temperatureData: Object
+    },
+    attached: function() {
+      this.async(function() {
+        this.$.temperatureFetcher.generateRequest();
+      }, 2);
     }
-
-    connectedCallback() {
-      super.connectedCallback();
-      this.$.temperatureFetcher.generateRequest();
-    }
-  }
-
-  customElements.define(WeatherChart.is, WeatherChart);
+  });
 </script>
 ----
 
@@ -349,24 +321,12 @@ Then, make sure that the request will be made.
 
 [source,javascript]
 ----
-class WeatherChart extends Polymer.Element {
-  static get is() { return 'weather-chart' }
-
-  static get properties() {
-    return {
-      temperatureData: Object,
-      humidityData: Object,
-    }
-  }
-
-  connectedCallback() {
-    super.connectedCallback();
+attached: function() {
+  this.async(function() {
     this.$.temperatureFetcher.generateRequest();
     this.$.humidityFetcher.generateRequest();
-  }
+  }, 2);
 }
-
-customElements.define(WeatherChart.is, WeatherChart);
 ----
 
 Finally, create a `<data-series>` element for humidity.

--- a/documentation/webcomponents-api/charts-installing.asciidoc
+++ b/documentation/webcomponents-api/charts-installing.asciidoc
@@ -15,7 +15,7 @@ If you are using http://bower.io[Bower] for managing your front-end dependencies
 
 [subs="normal"]
 ----
-[prompt]#$# [command]#bower# install --save vaadin-charts#[replaceable]#5.x.x#
+[prompt]#$# [command]#bower# install --save vaadin-charts#[replaceable]#3.x.x#
 ----
 
 Replace the version number with the most current one.
@@ -39,7 +39,7 @@ For an example, the following is how you could load `vaadin-line-chart` in the `
 [source, html]
 ----
 <link rel="import"
-      href="https://cdn.vaadin.com/vaadin-charts/5.0.0/vaadin-line-chart.html">
+      href="https://cdn.vaadin.com/vaadin-charts/3.2.0/vaadin-line-chart.html">
 ----
 
 Again, notice to specify the correct version number for Charts.


### PR DESCRIPTION
This reverts commit 2c0839f96b9d601dbd1d797f7ea0227273b0c9d4.
Charts 5.0.0 are not released yet, we can't publish docs yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/charts/435)
<!-- Reviewable:end -->
