### PR TITLE
Remove dependency to obsolete version of commons-io

### DIFF
--- a/addon/pom.xml
+++ b/addon/pom.xml
@@ -278,11 +278,6 @@
 			<artifactId>vaadin-client</artifactId>
 			<scope>provided</scope>
 		</dependency>
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>1.4</version>
-		</dependency>
 
 		<!-- Testing -->
 		<dependency>

--- a/addon/src/main/java/com/vaadin/addon/charts/util/SVGGenerator.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/util/SVGGenerator.java
@@ -27,8 +27,6 @@ import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 
-import org.apache.commons.io.IOUtils;
-
 import com.vaadin.addon.charts.Chart;
 import com.vaadin.addon.charts.ChartOptions;
 import com.vaadin.addon.charts.model.Configuration;
@@ -374,12 +372,12 @@ public class SVGGenerator {
                 InputStream resourceAsStream = Chart.class
                         .getResourceAsStream("/com/vaadin/addon/charts/client/"
                                 + string);
-                IOUtils.copy(resourceAsStream, out);
+                copy(resourceAsStream, out);
                 resourceAsStream.close();
             }
             InputStream resourceAsStream = SVGGenerator.class
                     .getResourceAsStream("vaadin-charts-formatter.js");
-            IOUtils.copy(resourceAsStream, out);
+            copy(resourceAsStream, out);
             resourceAsStream.close();
 
             out.close();
@@ -391,7 +389,7 @@ public class SVGGenerator {
             out = new FileOutputStream(JS_CONVERTER);
             resourceAsStream = SVGGenerator.class
                     .getResourceAsStream("phantomconverter.js");
-            IOUtils.copy(resourceAsStream, out);
+            copy(resourceAsStream, out);
             resourceAsStream.close();
             out.close();
         } catch (IOException e) {
@@ -402,5 +400,14 @@ public class SVGGenerator {
     private static boolean temporaryFilesExist() {
         return JS_STUFF != null && JS_STUFF.exists() && JS_CONVERTER != null
                 && JS_CONVERTER.exists();
+    }
+
+    private static void copy(InputStream input, OutputStream output)
+            throws IOException {
+        byte[] buffer = new byte[4096];
+        int n = 0;
+        while ((n = input.read(buffer)) != -1) {
+            output.write(buffer, 0, n);
+        }
     }
 }

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -72,12 +72,11 @@
             <artifactId>commons-io</artifactId>
             <version>2.4</version>
         </dependency>
-
         <dependency>
-                    <groupId>org.vaadin.addons</groupId>
-                    <artifactId>googleanalyticstracker</artifactId>
-                    <version>2.1.0</version>
-                </dependency>
+            <groupId>org.vaadin.addons</groupId>
+            <artifactId>googleanalyticstracker</artifactId>
+            <version>2.1.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/directory/assembly/README.txt
+++ b/directory/assembly/README.txt
@@ -46,7 +46,6 @@ Using plain Jar
 If you wan't to use the add-on jar directly, add it to your classpath. The add-on
 also depends on following Apache 2 licensed libraries:
  * Jackson
- * commons-io
 
 Unless you are already using them in your project add them also. They are also
 included in this zip package in the "lib" directory.

--- a/directory/assembly/license.html
+++ b/directory/assembly/license.html
@@ -124,7 +124,6 @@
     </p>
     <ul>
         <li><a href="https://github.com/FasterXML/jackson">Jackson</a>, licensed under <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>;</li>
-        <li><a href="http://commons.apache.org/proper/commons-io/">Commons IO</a>, licensed under <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a>.</li>
         <li><a href="https://www.polymer-project.org">Polymer</a>, licensed under <a href="http://polymer.github.io/LICENSE.txt">BSD License</a>.</li>
         <li><a href="http://webcomponents.org/polyfills/">webcomponents.js</a>, licensed under <a href="https://raw.githubusercontent.com/webcomponents/webcomponentsjs/master/LICENSE.md">BSD License</a>.</li>
     </ul>

--- a/directory/assembly/releasenotes.html
+++ b/directory/assembly/releasenotes.html
@@ -569,7 +569,6 @@
         Vaadin Charts 4 directly depends on the following third-party libraries:</p>
 
     <ul>
-        <li>Apache commons-io</li>
         <li>Jackson databind</li>
         <li>Polymer</li>
         <li>webcomponents.js</li>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -76,12 +76,6 @@
             <version>3.0.1</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.4</version>
-        </dependency>
-
 
         <!-- Test dependencies -->
         <dependency>


### PR DESCRIPTION
Obsolete version (1.4) of Apache commons-io is used in charts addon.
It is explicitly expressed in MANIFEST.MF thus forcing addon consumers
to ship with this obsolete 3rd-party library version.

Since it is used in single place only and only a single trivial method
of commons-io is used, remove the dependency completely and replace it
with 3 lines of code.

Originally in #453

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/charts/467)
<!-- Reviewable:end -->
