### PR TITLE
Fixes #475,convert Instant to epoch long correctly

### DIFF
--- a/addon/src/test/java/com/vaadin/addon/charts/model/junittests/ChartDataSeriesJSONSerializationTest.java
+++ b/addon/src/test/java/com/vaadin/addon/charts/model/junittests/ChartDataSeriesJSONSerializationTest.java
@@ -281,7 +281,7 @@ public class ChartDataSeriesJSONSerializationTest {
         chartDataSeries.setX(TestInstantItem::getDate);
         chartDataSeries.setY(TestInstantItem::getValue);
 
-        String expected = "{\"data\":[[" + instant.getEpochSecond() * 1000 + ",80]]}";
+        String expected = "{\"data\":[[" + instant.toEpochMilli() + ",80]]}";
         assertEquals(expected, toJSON(chartDataSeries));
     }
 

--- a/model/src/main/java/com/vaadin/addon/charts/util/Util.java
+++ b/model/src/main/java/com/vaadin/addon/charts/util/Util.java
@@ -39,7 +39,7 @@ public class Util {
      * @return
      */
     public static long toHighchartsTS(Instant date) {
-        return date.getEpochSecond()*1000;
+        return date.getEpochMilli();
     }
 
      /**

--- a/model/src/main/java/com/vaadin/addon/charts/util/Util.java
+++ b/model/src/main/java/com/vaadin/addon/charts/util/Util.java
@@ -39,7 +39,7 @@ public class Util {
      * @return
      */
     public static long toHighchartsTS(Instant date) {
-        return date.getEpochMilli();
+        return date.toEpochMilli();
     }
 
      /**


### PR DESCRIPTION
Convert Instant to epoch long with date.getEpochMilli, instead of with date.getEpochSeconds()*1000. New method retains milliseconds while the old method discards them

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/charts/476)
<!-- Reviewable:end -->
