### PR TITLE
Fix for Issue #483

### DIFF
--- a/addon/src/main/java/com/vaadin/addon/charts/Chart.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/Chart.java
@@ -383,11 +383,15 @@ public class Chart extends AbstractComponent {
 
     private DrilldownCallback drilldownCallback;
 
+    private DrillDownStateResetCallback drillDownStateResetCallback;
+
     private String jsonConfig;
 
     private Configuration configuration;
 
     private boolean stateDirty = false;
+
+    private ChartServerRpcImplementation srvRpcImpl;
 
     /**
      * Constructs a chart component with default settings.
@@ -401,7 +405,10 @@ public class Chart extends AbstractComponent {
         setHeight(400, Unit.PIXELS);
         configuration = new Configuration();
 
-        registerRpc(new ChartServerRpcImplementation(), ChartServerRpc.class);
+       /* System.out.println("Created a new chart");
+        System.err.println("Created a new chart");*/
+        srvRpcImpl = new ChartServerRpcImplementation();
+        registerRpc(srvRpcImpl, ChartServerRpc.class);
     }
 
     /**
@@ -689,6 +696,23 @@ public class Chart extends AbstractComponent {
      */
     public void setDrilldownCallback(DrilldownCallback drilldownCallback) {
         this.drilldownCallback = drilldownCallback;
+    }
+
+    /**
+     * Register a DrillResetCallBack that will be notified upon drilldown state reset
+     * @param drillDownStateResetCallback CallBack to notify
+     */
+    public void setDrillDownStateResetCallback(DrillDownStateResetCallback drillDownStateResetCallback) {
+        this.drillDownStateResetCallback = drillDownStateResetCallback;
+    }
+
+    /**
+     * Triggers a Drilldown state reset
+     */
+    public void resetDrillDownState() {
+        this.srvRpcImpl.drilldownStack.clear();
+        if (this.drillDownStateResetCallback != null)
+            this.drillDownStateResetCallback.handleDrillDownStateReset();
     }
 
     /**

--- a/addon/src/main/java/com/vaadin/addon/charts/DrillDownStateResetCallback.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/DrillDownStateResetCallback.java
@@ -1,0 +1,7 @@
+package com.vaadin.addon.charts;
+
+import java.io.Serializable;
+
+public interface DrillDownStateResetCallback extends Serializable {
+        void handleDrillDownStateReset();
+}


### PR DESCRIPTION
Here's a proposed fix for issue #483 , it provides a way to reset the drilldown state and also to notify listeners of the drilldown state of the reset.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/charts/484)
<!-- Reviewable:end -->
