### PR TITLE
Import extra resources even if Highcharts was already imported

### DIFF
--- a/addon/src/main/java/com/vaadin/addon/charts/client/HighchartsScriptLoader.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/client/HighchartsScriptLoader.java
@@ -48,6 +48,9 @@ public class HighchartsScriptLoader {
         // Inject highcharts only if not already injected
         if (!hasHighcharts()) {
             inject(HighchartResources.INSTANCE.highstock().getText());
+        }
+        // Inject other resources only if not already injected
+        if (!hasExtraImports()) {
             inject(HighchartResources.INSTANCE.noData().getText());
             inject(HighchartResources.INSTANCE.highchartsMore().getText());
             inject(HighchartResources.INSTANCE.funnel().getText());
@@ -71,6 +74,18 @@ public class HighchartsScriptLoader {
     protected native static boolean hasHighcharts()
     /*-{
         if($wnd.Highcharts)
+            return true;
+        return false;
+    }-*/;
+
+    /**
+     * Funnel should be enough to check that extra modules are missing
+     * 
+     * @return true if other imports were loaded
+     */
+    protected native static boolean hasExtraImports()
+    /*-{
+        if($wnd.Highcharts.seriesTypes.funnel)
             return true;
         return false;
     }-*/;


### PR DESCRIPTION
According to [highcharts forum](https://forum.highcharts.com/highcharts-usage/reliable-way-to-check-if-modules-are-imported-map-stock-t40283/) we could check for each module, but with Highcharts 4.2.6 it's not possible, so now we will check for one module and import all of them even if Highcharts was already defined.