### PR TITLE
Reset drilldownStack on initial response

### DIFF
--- a/addon/src/main/java/com/vaadin/addon/charts/Chart.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/Chart.java
@@ -328,6 +328,10 @@ public class Chart extends AbstractComponent {
             fireEvent(event);
         }
 
+        public void clearDrilldownStack() {
+            drilldownStack.clear();
+        }
+
         private Series resolveSeriesFor(int seriesIndex) {
             Series series;
             if (drilldownStack.isEmpty()) {
@@ -368,6 +372,7 @@ public class Chart extends AbstractComponent {
         PointSelectListener.class, "onSelect", PointSelectEvent.class);
     private final static Method pointUnselectMethod = ReflectTools.findMethod(
         PointUnselectListener.class, "onUnselect", PointUnselectEvent.class);
+    private ChartServerRpcImplementation srvRpcImpl;
 
     private final static List<ChartType> TIMELINE_NOT_SUPPORTED = Arrays.asList(
         ChartType.PIE, ChartType.GAUGE, ChartType.SOLIDGAUGE, ChartType.PYRAMID,
@@ -400,8 +405,8 @@ public class Chart extends AbstractComponent {
         setWidth(100, Unit.PERCENTAGE);
         setHeight(400, Unit.PIXELS);
         configuration = new Configuration();
-
-        registerRpc(new ChartServerRpcImplementation(), ChartServerRpc.class);
+        srvRpcImpl = new ChartServerRpcImplementation();
+        registerRpc(srvRpcImpl, ChartServerRpc.class);
     }
 
     /**
@@ -431,6 +436,9 @@ public class Chart extends AbstractComponent {
                 configuration == null ? null : toJSON(configuration);
             getState().jsonState = jsonConfig;
             stateDirty = false;
+        }
+        if (initial) {
+            srvRpcImpl.clearDrilldownStack();
         }
         if (configuration != null) {
             // Start listening to data series events once the chart has been

--- a/examples/src/main/java/com/vaadin/addon/charts/examples/columnandbar/ChartWithLazyDrilldownInTabSheet.java
+++ b/examples/src/main/java/com/vaadin/addon/charts/examples/columnandbar/ChartWithLazyDrilldownInTabSheet.java
@@ -1,0 +1,36 @@
+package com.vaadin.addon.charts.examples.columnandbar;
+
+import com.vaadin.addon.charts.Chart;
+import com.vaadin.addon.charts.examples.AbstractVaadinChartExample;
+import com.vaadin.addon.charts.examples.SkipFromDemo;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.TabSheet;
+
+@SkipFromDemo
+public class ChartWithLazyDrilldownInTabSheet
+        extends AbstractVaadinChartExample {
+
+    /**
+     * 
+     * Test UI for #483.
+     * 
+     * To reproduce issue:
+     * <ul>
+     * <li>Click on IE</li>
+     * <li>Change to second tab</li>
+     * <li>Change to first tab</li>
+     * <li>Click on opera</li>
+     * </ul>
+     */
+    @Override
+    protected Component getChart() {
+        TabSheet tabs = new TabSheet();
+        tabs.setSizeFull();
+        Chart chart = (Chart) new ColumnWithNativeLazyDrilldown().getChart();
+        tabs.addTab(chart, "First tab with chart");
+        Label label = new Label("second tab content");
+        tabs.addTab(label, "Other tab");
+        return tabs;
+    }
+}


### PR DESCRIPTION
Alternative fix for #483
Added a test UI but for some reason the error indicator is not shown in the chart in the tabsheet and didn't want to add a more complex check for a missing error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/charts/502)
<!-- Reviewable:end -->
