### PR TITLE
Fix for Issue #508 : Highchart Global options cannot be set

### DIFF
--- a/addon/src/main/java/com/vaadin/addon/charts/ChartOptions.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/ChartOptions.java
@@ -22,6 +22,7 @@ import static com.vaadin.addon.charts.util.ChartSerialization.toJSON;
 import java.util.Iterator;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.vaadin.addon.charts.model.Global;
 import com.vaadin.addon.charts.model.Lang;
 import com.vaadin.addon.charts.model.style.Theme;
 import com.vaadin.addon.charts.shared.ChartOptionsState;
@@ -44,6 +45,8 @@ public class ChartOptions extends AbstractExtension {
     private Theme theme;
 
     private Lang lang;
+
+    private Global global;
 
     protected ChartOptions() {
     }
@@ -98,6 +101,28 @@ public class ChartOptions extends AbstractExtension {
     public Theme getTheme() {
         return theme;
     }
+
+    /**
+     * Changes the Global params of all charts.
+     *
+     * @param global
+     */
+    public void setGlobal(Global global) {
+        this.global = global;
+        buildOptionsJson();
+        notifyListeners();
+    }
+
+    /**
+     * Returns the {@link Global} in use or {@code null} if no lang configuration
+     * has been set.
+     *
+     * @return the {@link Global} in use or {@code null}.
+     */
+    public Global getGlobal() {
+        return global;
+    }
+
 
     /**
      * Changes the language of all charts.

--- a/addon/src/main/java/com/vaadin/addon/charts/model/serializers/ChartOptionsBeanSerializerModifier.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/model/serializers/ChartOptionsBeanSerializerModifier.java
@@ -41,13 +41,13 @@ public class ChartOptionsBeanSerializerModifier extends
             List<BeanPropertyWriter> beanProperties) {
 
         if (ChartOptions.class.isAssignableFrom(beanDesc.getBeanClass())) {
-            // make sure we only serialize the lang and theme fields from
+            // make sure we only serialize the lang, theme and global fields from
             // ChartOptions, otherwise everything from parent would be
             // serialized
             List<BeanPropertyWriter> newProperties = new ArrayList<BeanPropertyWriter>();
 
             for (BeanPropertyWriter writer : beanProperties) {
-                if ("lang" == writer.getName() || "theme" == writer.getName()) {
+                if ("lang" == writer.getName() || "theme" == writer.getName() || "global" == writer.getName()) {
                     newProperties.add(writer);
                 }
             }

--- a/addon/src/test/java/com/vaadin/addon/charts/model/junittests/ChartOptionsJSONSerializationTest.java
+++ b/addon/src/test/java/com/vaadin/addon/charts/model/junittests/ChartOptionsJSONSerializationTest.java
@@ -1,15 +1,10 @@
 package com.vaadin.addon.charts.model.junittests;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.vaadin.addon.charts.ChartOptions;
-import com.vaadin.addon.charts.model.DataSeries;
-import com.vaadin.addon.charts.model.DataSeriesItem;
-import com.vaadin.addon.charts.model.Lang;
-import com.vaadin.addon.charts.model.style.GradientColor;
-import com.vaadin.addon.charts.model.style.SolidColor;
-import com.vaadin.addon.charts.model.style.Theme;
-import com.vaadin.addon.charts.util.ChartSerialization;
-import com.vaadin.ui.UI;
+import static com.vaadin.addon.charts.util.ChartSerialization.toJSON;
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -17,10 +12,17 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import java.io.IOException;
-
-import static com.vaadin.addon.charts.util.ChartSerialization.toJSON;
-import static org.junit.Assert.assertEquals;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vaadin.addon.charts.ChartOptions;
+import com.vaadin.addon.charts.model.DataSeries;
+import com.vaadin.addon.charts.model.DataSeriesItem;
+import com.vaadin.addon.charts.model.Global;
+import com.vaadin.addon.charts.model.Lang;
+import com.vaadin.addon.charts.model.style.GradientColor;
+import com.vaadin.addon.charts.model.style.SolidColor;
+import com.vaadin.addon.charts.model.style.Theme;
+import com.vaadin.addon.charts.util.ChartSerialization;
+import com.vaadin.ui.UI;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ChartOptionsJSONSerializationTest {
@@ -52,6 +54,15 @@ public class ChartOptionsJSONSerializationTest {
         options.setTheme(theme);
 
         assertEquals(EmptyThemeJson, toJSON(options));
+    }
+
+    @Test
+    public void toJSON_GlobalSet_GlobalSerialized() {
+        Global global = new Global();
+        global.setUseUTC(false);
+        options.setGlobal(global);
+
+        assertEquals("{\"global\":{\"useUTC\":false}}", toJSON(options));
     }
 
     @Test


### PR DESCRIPTION
These changes will add HighChart Global configuration to ChartOptions and allow it to be serialized and pushed back to the client.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/charts/509)
<!-- Reviewable:end -->
