### PR TITLE
Fix exception on axis extreme change events when chart has no data

### DIFF
--- a/addon/src/main/java/com/vaadin/addon/charts/client/ui/SetExtremesEvent.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/client/ui/SetExtremesEvent.java
@@ -32,12 +32,20 @@ public class SetExtremesEvent extends JavaScriptObject {
 
     public native final double getMin()
     /*-{
-        return this.min;
+        if (this.min) {
+          return this.min;
+        } else {
+          return 0;
+        }
     }-*/;
 
     public native final double getMax()
     /*-{
-        return this.max;
+        if (this.max) {
+          return this.max;
+        } else {
+          return 0;
+        }
     }-*/;
 
 }

--- a/examples/src/main/java/com/vaadin/addon/charts/examples/dynamic/LineWithHideDataButton.java
+++ b/examples/src/main/java/com/vaadin/addon/charts/examples/dynamic/LineWithHideDataButton.java
@@ -1,0 +1,45 @@
+package com.vaadin.addon.charts.examples.dynamic;
+
+import com.vaadin.addon.charts.Chart;
+import com.vaadin.addon.charts.examples.AbstractVaadinChartExample;
+import com.vaadin.addon.charts.examples.SkipFromDemo;
+import com.vaadin.addon.charts.model.Configuration;
+import com.vaadin.addon.charts.model.ListSeries;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.VerticalLayout;
+
+@SkipFromDemo
+public class LineWithHideDataButton extends AbstractVaadinChartExample {
+
+    @Override
+    public String getDescription() {
+        return "Basic Line With Data Labels";
+    }
+
+    @Override
+    protected Component getChart() {
+        Label extremes = new Label();
+        extremes.setId("extremesLabel");
+
+        Chart chart = new Chart();
+
+        Configuration configuration = chart.getConfiguration();
+
+        ListSeries ls = new ListSeries();
+        ls.setData(7.0, 6.9, 9.5, 14.5, 18.2, 21.5, 25.2, 26.5, 23.3, 18.3,
+                13.9, 9.6);
+        configuration.addSeries(ls);
+        chart.addXAxesExtremesChangeListener((event) -> extremes.setValue(
+                "Min " + event.getMinimum() + " Max: " + event.getMaximum()));
+
+        final Button showHideSeries = new Button("Show/Hide series");
+        showHideSeries.setId("showHideSeriesButton");
+        showHideSeries
+                .addClickListener((e) -> ls.setVisible(!ls.isVisible()));
+
+        return new VerticalLayout(showHideSeries, extremes, chart);
+    }
+
+}

--- a/integration-tests/src/test/java/com/vaadin/addon/charts/testbenchtests/LineWithHideDataButtonTBTest.java
+++ b/integration-tests/src/test/java/com/vaadin/addon/charts/testbenchtests/LineWithHideDataButtonTBTest.java
@@ -1,0 +1,41 @@
+package com.vaadin.addon.charts.testbenchtests;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.addon.charts.examples.dynamic.LineWithHideDataButton;
+import com.vaadin.testbench.elements.ButtonElement;
+import com.vaadin.testbench.elements.LabelElement;
+
+public class LineWithHideDataButtonTBTest extends AbstractParallelTest {
+
+
+    @Override
+    protected String getTestViewName() {
+        return LineWithHideDataButton.class.getSimpleName();
+    }
+
+    @Override
+    protected String getPackageName() {
+        return "dynamic";
+    }
+
+    private void openTestUI() {
+        driver.get(getTestUrl());
+        waitUntilChartRendered();
+    }
+
+    @Test
+    public void hideData_ocurred_extremesChanged() {
+        openTestUI();
+        
+        ButtonElement showHideSeriesButton = $(ButtonElement.class).id("showHideSeriesButton");
+        LabelElement extremesLabel = $(LabelElement.class).id("extremesLabel");
+        
+        showHideSeriesButton.click();
+        Assert.assertEquals("Min 0.0 Max: 0.0", extremesLabel.getText());
+        showHideSeriesButton.click();
+        Assert.assertNotEquals("Min 0.0 Max: 0.0",  extremesLabel.getText());
+    }
+
+}


### PR DESCRIPTION
Missing extremes min and max will be sent as 0, as done in other events
Fixes #549

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/charts/550)
<!-- Reviewable:end -->
