### PR TITLE
Use JSONParser.parseStrict when possible

### DIFF
--- a/addon/src/main/java/com/vaadin/addon/charts/client/ui/ChartOptionsConnector.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/client/ui/ChartOptionsConnector.java
@@ -39,7 +39,7 @@ public class ChartOptionsConnector extends AbstractExtensionConnector {
         super.onStateChanged(event);
 
         if (getState().json != null) {
-            JavaScriptObject options = JSONParser.parseLenient(getState().json)
+            JavaScriptObject options = JSONParser.parseStrict(getState().json)
                     .isObject().getJavaScriptObject();
             applyOptions(options);
         }

--- a/addon/src/main/java/com/vaadin/addon/charts/client/ui/HighchartConfig.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/client/ui/HighchartConfig.java
@@ -31,7 +31,7 @@ public class HighchartConfig extends JavaScriptObject {
             String jsonState) {
         HighchartConfig conf;
         if (confStr != null) {
-            conf = (HighchartConfig) JSONParser.parseLenient(confStr)
+            conf = (HighchartConfig) JSONParser.parseStrict(confStr)
                     .isObject().getJavaScriptObject();
             conf.prepare();
         } else {


### PR DESCRIPTION
parseLenient uses eval which can lead to memory leaks
eval is still used for jsonState to avoid a breaking change in examples like JSAndJavaApi
and in function evaluation for formatters and other function properties

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/charts/567)
<!-- Reviewable:end -->
