### PR TITLE
Fix configuration setSeries/addSeries exception

### DIFF
--- a/addon/src/main/java/com/vaadin/addon/charts/model/Configuration.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/model/Configuration.java
@@ -139,7 +139,7 @@ public class Configuration extends AbstractConfigurationObject
      * @param series
      */
     public void setSeries(Series... series) {
-        setSeries(Arrays.asList(series));
+        setSeries(new ArrayList<>(Arrays.asList(series)));
     }
 
     /**

--- a/addon/src/test/java/com/vaadin/addon/charts/model/junittests/ConfigurationJSONSerializationTest.java
+++ b/addon/src/test/java/com/vaadin/addon/charts/model/junittests/ConfigurationJSONSerializationTest.java
@@ -15,6 +15,7 @@ import com.vaadin.addon.charts.events.SeriesChangedEvent;
 import com.vaadin.addon.charts.events.SeriesStateEvent;
 import com.vaadin.addon.charts.model.Configuration;
 import com.vaadin.addon.charts.model.Lang;
+import com.vaadin.addon.charts.model.ListSeries;
 import com.vaadin.addon.charts.model.Series;
 import com.vaadin.addon.charts.model.YAxis;
 
@@ -111,6 +112,16 @@ public class ConfigurationJSONSerializationTest {
         Configuration conf = new Configuration();
         assertEquals(
           "{\"plotOptions\":{},\"series\":[],\"exporting\":{\"enabled\":false}}",
+          toJSON(conf));
+    }
+
+    @Test
+    public void configurationJSONSerialization_setSeriesAddSeries_noExceptions() {
+        Configuration conf = new Configuration();
+        conf.setSeries(new ListSeries(),new ListSeries());
+        conf.addSeries(new ListSeries());
+        assertEquals(
+          "{\"plotOptions\":{},\"series\":[{\"data\":[]},{\"data\":[]},{\"data\":[]}],\"exporting\":{\"enabled\":false}}",
           toJSON(conf));
     }
 }


### PR DESCRIPTION
when using setSeries(Series ... series) is used, currently it will result in configuration.series be of class Arrays#ArrayList, which is readonly (which leads to a complicated to debug UnsupportedOperationException, when addSeries is used later). 

To be consistent with the initial state, where it is the readwrite ArrayList, a simple wrapping can be used. If a certain type of a List (e.g. readonly) is needed, setSeries(List<Series> series) can still be used

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/charts/576)
<!-- Reviewable:end -->
