### PR TITLE
Update instructions to use https for Maven repositories

### DIFF
--- a/documentation/java-api/charts-installing.asciidoc
+++ b/documentation/java-api/charts-installing.asciidoc
@@ -40,7 +40,7 @@ You also need to define the Vaadin add-ons repository if not already defined:
 ----
 <repository>
    <id>vaadin-addons</id>
-   <url>http://maven.vaadin.com/vaadin-addons</url>
+   <url>https://maven.vaadin.com/vaadin-addons</url>
 </repository>
 ----
 


### PR DESCRIPTION
See https://github.com/vaadin/platform/issues/766

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/charts/582)
<!-- Reviewable:end -->
