### PR TITLE
test: temporarily disable skies theme test

### DIFF
--- a/integration-tests/src/test/java/com/vaadin/addon/charts/testbenchtests/SkiesThemedBarChartTBTest.java
+++ b/integration-tests/src/test/java/com/vaadin/addon/charts/testbenchtests/SkiesThemedBarChartTBTest.java
@@ -1,7 +1,10 @@
 package com.vaadin.addon.charts.testbenchtests;
 
+import org.junit.Ignore;
+
 import com.vaadin.addon.charts.examples.themes.SkiesThemedBarChart;
 
+@Ignore
 public class SkiesThemedBarChartTBTest extends
         AbstractSimpleScreenShotTestBenchTest {
 

--- a/integration-tests/src/test/java/com/vaadin/addon/charts/testbenchtests/SkiesThemedBarChartTBTest.java
+++ b/integration-tests/src/test/java/com/vaadin/addon/charts/testbenchtests/SkiesThemedBarChartTBTest.java
@@ -4,6 +4,7 @@ import org.junit.Ignore;
 
 import com.vaadin.addon.charts.examples.themes.SkiesThemedBarChart;
 
+// Ignoring for now because the test view uses an image that is pointing to an URL that no longer works.
 @Ignore
 public class SkiesThemedBarChartTBTest extends
         AbstractSimpleScreenShotTestBenchTest {


### PR DESCRIPTION
The test view uses an image that is pointing to an URL that no longer works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/charts/601)
<!-- Reviewable:end -->
