### PR TITLE
fix: Change listeners to implement SerializableEventListener

### DIFF
--- a/addon/src/main/java/com/vaadin/addon/charts/ChartClickListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/ChartClickListener.java
@@ -17,8 +17,6 @@ package com.vaadin.addon.charts;
  * #L%
  */
 
-import java.io.Serializable;
-
 import com.vaadin.event.SerializableEventListener;
 
 /**

--- a/addon/src/main/java/com/vaadin/addon/charts/ChartClickListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/ChartClickListener.java
@@ -19,11 +19,13 @@ package com.vaadin.addon.charts;
 
 import java.io.Serializable;
 
+import com.vaadin.event.SerializableEventListener;
+
 /**
  * Listener interface for click events on the chart's area
  */
 @FunctionalInterface
-public interface ChartClickListener extends Serializable {
+public interface ChartClickListener extends SerializableEventListener {
 
     /**
      * Called when the user clicks somewhere on the chart.

--- a/addon/src/main/java/com/vaadin/addon/charts/ChartDrillupListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/ChartDrillupListener.java
@@ -19,11 +19,13 @@ package com.vaadin.addon.charts;
 
 import java.io.Serializable;
 
+import com.vaadin.event.SerializableEventListener;
+
 /**
  * Listener interface for drillup events on the chart
  */
 @FunctionalInterface
-public interface ChartDrillupListener extends Serializable {
+public interface ChartDrillupListener extends SerializableEventListener {
 
     /**
      * Called when the user clicks the 'Back to previous series' button.

--- a/addon/src/main/java/com/vaadin/addon/charts/ChartDrillupListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/ChartDrillupListener.java
@@ -17,8 +17,6 @@ package com.vaadin.addon.charts;
  * #L%
  */
 
-import java.io.Serializable;
-
 import com.vaadin.event.SerializableEventListener;
 
 /**

--- a/addon/src/main/java/com/vaadin/addon/charts/ChartSelectionListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/ChartSelectionListener.java
@@ -17,8 +17,6 @@ package com.vaadin.addon.charts;
  * #L%
  */
 
-import java.io.Serializable;
-
 import com.vaadin.event.SerializableEventListener;
 
 /**

--- a/addon/src/main/java/com/vaadin/addon/charts/ChartSelectionListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/ChartSelectionListener.java
@@ -19,11 +19,13 @@ package com.vaadin.addon.charts;
 
 import java.io.Serializable;
 
+import com.vaadin.event.SerializableEventListener;
+
 /**
  * Listener interface for chart selection events
  */
 @FunctionalInterface
-public interface ChartSelectionListener extends Serializable {
+public interface ChartSelectionListener extends SerializableEventListener {
 
     /**
      * Called when the user finishes the selection of an area on the X axis.

--- a/addon/src/main/java/com/vaadin/addon/charts/CheckboxClickListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/CheckboxClickListener.java
@@ -17,8 +17,6 @@ package com.vaadin.addon.charts;
  * #L%
  */
 
-import java.io.Serializable;
-
 import com.vaadin.event.SerializableEventListener;
 
 /**

--- a/addon/src/main/java/com/vaadin/addon/charts/CheckboxClickListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/CheckboxClickListener.java
@@ -19,11 +19,13 @@ package com.vaadin.addon.charts;
 
 import java.io.Serializable;
 
+import com.vaadin.event.SerializableEventListener;
+
 /**
  * Listener interface for checkbox click events
  */
 @FunctionalInterface
-public interface CheckboxClickListener extends Serializable {
+public interface CheckboxClickListener extends SerializableEventListener {
 
     /**
      * Called when the user has clicked a checkbox in the legend

--- a/addon/src/main/java/com/vaadin/addon/charts/LegendItemClickListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/LegendItemClickListener.java
@@ -17,8 +17,6 @@ package com.vaadin.addon.charts;
  * #L%
  */
 
-import java.io.Serializable;
-
 import com.vaadin.event.SerializableEventListener;
 
 /**

--- a/addon/src/main/java/com/vaadin/addon/charts/LegendItemClickListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/LegendItemClickListener.java
@@ -19,11 +19,13 @@ package com.vaadin.addon.charts;
 
 import java.io.Serializable;
 
+import com.vaadin.event.SerializableEventListener;
+
 /**
  * Listener interface for legend item click events
  */
 @FunctionalInterface
-public interface LegendItemClickListener extends Serializable {
+public interface LegendItemClickListener extends SerializableEventListener {
 
     /**
      * Called when the user click an item in the chart's legend

--- a/addon/src/main/java/com/vaadin/addon/charts/PointClickListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/PointClickListener.java
@@ -17,8 +17,6 @@ package com.vaadin.addon.charts;
  * #L%
  */
 
-import java.io.Serializable;
-
 import com.vaadin.event.SerializableEventListener;
 
 /**

--- a/addon/src/main/java/com/vaadin/addon/charts/PointClickListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/PointClickListener.java
@@ -19,11 +19,13 @@ package com.vaadin.addon.charts;
 
 import java.io.Serializable;
 
+import com.vaadin.event.SerializableEventListener;
+
 /**
  * Listener interface for click events on the data points of the chart
  */
 @FunctionalInterface
-public interface PointClickListener extends Serializable {
+public interface PointClickListener extends SerializableEventListener {
     /**
      * Called when a data point is clicked by the user.
      * 

--- a/addon/src/main/java/com/vaadin/addon/charts/PointSelectListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/PointSelectListener.java
@@ -19,11 +19,13 @@ package com.vaadin.addon.charts;
 
 import java.io.Serializable;
 
+import com.vaadin.event.SerializableEventListener;
+
 /**
  * Listener interface for select events on the data points of the chart
  */
 @FunctionalInterface
-public interface PointSelectListener extends Serializable {
+public interface PointSelectListener extends SerializableEventListener {
     /**
      * Called when a data point is selected
      *

--- a/addon/src/main/java/com/vaadin/addon/charts/PointSelectListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/PointSelectListener.java
@@ -17,8 +17,6 @@ package com.vaadin.addon.charts;
  * #L%
  */
 
-import java.io.Serializable;
-
 import com.vaadin.event.SerializableEventListener;
 
 /**

--- a/addon/src/main/java/com/vaadin/addon/charts/PointUnselectListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/PointUnselectListener.java
@@ -17,8 +17,6 @@ package com.vaadin.addon.charts;
  * #L%
  */
 
-import java.io.Serializable;
-
 import com.vaadin.event.SerializableEventListener;
 
 /**

--- a/addon/src/main/java/com/vaadin/addon/charts/PointUnselectListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/PointUnselectListener.java
@@ -19,11 +19,13 @@ package com.vaadin.addon.charts;
 
 import java.io.Serializable;
 
+import com.vaadin.event.SerializableEventListener;
+
 /**
  * Listener interface for unselect events on the data points of the chart
  */
 @FunctionalInterface
-public interface PointUnselectListener extends Serializable {
+public interface PointUnselectListener extends SerializableEventListener {
 
     /**
      * Called when a data point is selected

--- a/addon/src/main/java/com/vaadin/addon/charts/SeriesHideListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/SeriesHideListener.java
@@ -17,8 +17,6 @@ package com.vaadin.addon.charts;
  * #L%
  */
 
-import java.io.Serializable;
-
 import com.vaadin.event.SerializableEventListener;
 
 /**

--- a/addon/src/main/java/com/vaadin/addon/charts/SeriesHideListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/SeriesHideListener.java
@@ -19,11 +19,13 @@ package com.vaadin.addon.charts;
 
 import java.io.Serializable;
 
+import com.vaadin.event.SerializableEventListener;
+
 /**
  * Listener interface for series hide events
  */
 @FunctionalInterface
-public interface SeriesHideListener extends Serializable {
+public interface SeriesHideListener extends SerializableEventListener {
 
     /**
      * Called when a series is hidden

--- a/addon/src/main/java/com/vaadin/addon/charts/SeriesShowListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/SeriesShowListener.java
@@ -17,8 +17,6 @@ package com.vaadin.addon.charts;
  * #L%
  */
 
-import java.io.Serializable;
-
 import com.vaadin.event.SerializableEventListener;
 
 /**

--- a/addon/src/main/java/com/vaadin/addon/charts/SeriesShowListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/SeriesShowListener.java
@@ -19,11 +19,13 @@ package com.vaadin.addon.charts;
 
 import java.io.Serializable;
 
+import com.vaadin.event.SerializableEventListener;
+
 /**
  * Listener interface for series show events
  */
 @FunctionalInterface
-public interface SeriesShowListener extends Serializable {
+public interface SeriesShowListener extends SerializableEventListener {
 
     /**
      * Called when a series is shown

--- a/addon/src/main/java/com/vaadin/addon/charts/XAxesExtremesChangeListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/XAxesExtremesChangeListener.java
@@ -17,8 +17,6 @@ package com.vaadin.addon.charts;
  * #L%
  */
 
-import java.io.Serializable;
-
 import com.vaadin.event.SerializableEventListener;
 
 /**

--- a/addon/src/main/java/com/vaadin/addon/charts/XAxesExtremesChangeListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/XAxesExtremesChangeListener.java
@@ -19,11 +19,13 @@ package com.vaadin.addon.charts;
 
 import java.io.Serializable;
 
+import com.vaadin.event.SerializableEventListener;
+
 /**
  * Listener interface for X axes extremes changed events
  */
 @FunctionalInterface
-public interface XAxesExtremesChangeListener extends Serializable {
+public interface XAxesExtremesChangeListener extends SerializableEventListener {
 
     /**
      * Called when a X axis extremes has changed

--- a/addon/src/main/java/com/vaadin/addon/charts/YAxesExtremesChangeListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/YAxesExtremesChangeListener.java
@@ -17,8 +17,6 @@ package com.vaadin.addon.charts;
  * #L%
  */
 
-import java.io.Serializable;
-
 import com.vaadin.event.SerializableEventListener;
 
 /**

--- a/addon/src/main/java/com/vaadin/addon/charts/YAxesExtremesChangeListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/YAxesExtremesChangeListener.java
@@ -19,11 +19,13 @@ package com.vaadin.addon.charts;
 
 import java.io.Serializable;
 
+import com.vaadin.event.SerializableEventListener;
+
 /**
  * Listener interface for Y axes extremes changed events
  */
 @FunctionalInterface
-public interface YAxesExtremesChangeListener extends Serializable {
+public interface YAxesExtremesChangeListener extends SerializableEventListener {
 
     /**
      * Called when a Y axis extremes has changed

--- a/addon/src/main/java/com/vaadin/addon/charts/events/ConfigurationChangeListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/events/ConfigurationChangeListener.java
@@ -17,8 +17,6 @@ package com.vaadin.addon.charts.events;
  * #L%
  */
 
-import java.io.Serializable;
-
 import com.vaadin.addon.charts.model.Series;
 import com.vaadin.event.SerializableEventListener;
 

--- a/addon/src/main/java/com/vaadin/addon/charts/events/ConfigurationChangeListener.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/events/ConfigurationChangeListener.java
@@ -20,6 +20,7 @@ package com.vaadin.addon.charts.events;
 import java.io.Serializable;
 
 import com.vaadin.addon.charts.model.Series;
+import com.vaadin.event.SerializableEventListener;
 
 /**
  * Listener interface for events triggered in Configuration. E.g. in DataSeries,
@@ -28,7 +29,7 @@ import com.vaadin.addon.charts.model.Series;
  * @since 2.0
  * 
  */
-public interface ConfigurationChangeListener extends Serializable {
+public interface ConfigurationChangeListener extends SerializableEventListener {
     /**
      * A data point has been added
      *


### PR DESCRIPTION
From Vaadin 8.12.0 onwards warning is logged if listener that is not extending SerializableEventListener is added to global event broker. Ref. https://github.com/vaadin/framework/pull/12045

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/charts/614)
<!-- Reviewable:end -->
