### PR TITLE
chore: bump jackson-databind from 2.9.10.8 to 2.15.2 in /addon

### DIFF
--- a/addon/pom.xml
+++ b/addon/pom.xml
@@ -252,7 +252,12 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.9.10.8</version>
+			<version>2.15.2</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
+			<version>2.15.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.vaadin</groupId>

--- a/addon/src/main/java/com/vaadin/addon/charts/model/serializers/BeanSerializerDelegator.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/model/serializers/BeanSerializerDelegator.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
 import com.fasterxml.jackson.databind.ser.impl.BeanAsArraySerializer;
 import com.fasterxml.jackson.databind.ser.impl.ObjectIdWriter;
 import com.fasterxml.jackson.databind.ser.std.BeanSerializerBase;
@@ -46,12 +47,27 @@ public class BeanSerializerDelegator<T> extends BeanSerializerBase {
         super(source, objectIdWriter);
     }
 
-    public BeanSerializerDelegator(BeanSerializerBase source, String[] toIgnore) {
+    @Deprecated
+    public BeanSerializerDelegator(BeanSerializerBase source,
+            String[] toIgnore) {
         super(source, toIgnore);
     }
 
-    protected BeanSerializerDelegator(BeanSerializerBase source, Set<String> toIgnore) {
+    @Deprecated
+    protected BeanSerializerDelegator(BeanSerializerBase source,
+            Set<String> toIgnore) {
         super(source, toIgnore);
+    }
+
+    protected BeanSerializerDelegator(BeanSerializerBase source,
+            Set<String> toIgnore, Set<String> toInclude) {
+        super(source, toIgnore, toInclude);
+    }
+
+    protected BeanSerializerDelegator(BeanSerializerBase source,
+            BeanPropertyWriter[] properties,
+            BeanPropertyWriter[] filteredProperties) {
+        super(source, properties, filteredProperties);
     }
 
     public BeanSerializerDelegator(BeanSerializerBase source, Object filterId) {
@@ -66,23 +82,39 @@ public class BeanSerializerDelegator<T> extends BeanSerializerBase {
     }
 
     @Override
-    public BeanSerializerBase withObjectIdWriter(ObjectIdWriter objectIdWriter) {
-        return new BeanSerializerDelegator(this, objectIdWriter);
+    public BeanSerializerBase withObjectIdWriter(
+            ObjectIdWriter objectIdWriter) {
+        return new BeanSerializerDelegator<>(this, objectIdWriter);
     }
 
     @Override
+    @Deprecated
     protected BeanSerializerBase withIgnorals(String[] toIgnore) {
-        return new BeanSerializerDelegator(this, toIgnore);
+        return new BeanSerializerDelegator<>(this, toIgnore);
     }
 
     @Override
+    @Deprecated
     protected BeanSerializerBase withIgnorals(Set<String> toIgnore) {
-        return new BeanSerializerDelegator(this, toIgnore);
+        return new BeanSerializerDelegator<>(this, toIgnore);
     }
 
     @Override
     public BeanSerializerBase withFilterId(Object filterId) {
-        return new BeanSerializerDelegator(this, filterId);
+        return new BeanSerializerDelegator<>(this, filterId);
+    }
+
+    @Override
+    protected BeanSerializerBase withByNameInclusion(Set<String> toIgnore,
+            Set<String> toInclude) {
+        return new BeanSerializerDelegator<>(this, toIgnore, toInclude);
+    }
+
+    @Override
+    protected BeanSerializerBase withProperties(BeanPropertyWriter[] properties,
+            BeanPropertyWriter[] filteredProperties) {
+        return new BeanSerializerDelegator<>(this, properties,
+                filteredProperties);
     }
 
     @Override

--- a/addon/src/main/java/com/vaadin/addon/charts/model/serializers/ThemeGradientColorBeanSerializer.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/model/serializers/ThemeGradientColorBeanSerializer.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
 import com.fasterxml.jackson.databind.ser.impl.BeanAsArraySerializer;
 import com.fasterxml.jackson.databind.ser.impl.ObjectIdWriter;
 import com.fasterxml.jackson.databind.ser.std.BeanSerializerBase;
@@ -44,14 +45,27 @@ public class ThemeGradientColorBeanSerializer extends BeanSerializerBase {
         super(source, objectIdWriter);
     }
 
+    @Deprecated
     public ThemeGradientColorBeanSerializer(BeanSerializerBase source,
             String[] toIgnore) {
         super(source, toIgnore);
     }
 
+    @Deprecated
     protected ThemeGradientColorBeanSerializer(BeanSerializerBase source,
             Set<String> toIgnore) {
         super(source, toIgnore);
+    }
+
+    protected ThemeGradientColorBeanSerializer(BeanSerializerBase source,
+            Set<String> toIgnore, Set<String> toInclude) {
+        super(source, toIgnore, toInclude);
+    }
+
+    protected ThemeGradientColorBeanSerializer(BeanSerializerBase source,
+            BeanPropertyWriter[] properties,
+            BeanPropertyWriter[] filteredProperties) {
+        super(source, properties, filteredProperties);
     }
 
     public ThemeGradientColorBeanSerializer(BeanSerializerBase source,
@@ -65,11 +79,13 @@ public class ThemeGradientColorBeanSerializer extends BeanSerializerBase {
     }
 
     @Override
+    @Deprecated
     protected BeanSerializerBase withIgnorals(String[] toIgnore) {
         return new ThemeGradientColorBeanSerializer(this, toIgnore);
     }
 
     @Override
+    @Deprecated
     protected BeanSerializerBase withIgnorals(Set<String> toIgnore) {
         return new ThemeGradientColorBeanSerializer(this, toIgnore);
     }
@@ -77,6 +93,19 @@ public class ThemeGradientColorBeanSerializer extends BeanSerializerBase {
     @Override
     public BeanSerializerBase withFilterId(Object filterId) {
         return new ThemeGradientColorBeanSerializer(this, filterId);
+    }
+
+    @Override
+    protected BeanSerializerBase withByNameInclusion(Set<String> toIgnore,
+            Set<String> toInclude) {
+        return new ThemeGradientColorBeanSerializer(this, toIgnore, toInclude);
+    }
+
+    @Override
+    protected BeanSerializerBase withProperties(BeanPropertyWriter[] properties,
+            BeanPropertyWriter[] filteredProperties) {
+        return new ThemeGradientColorBeanSerializer(this, properties,
+                filteredProperties);
     }
 
     @Override

--- a/addon/src/main/java/com/vaadin/addon/charts/util/ChartSerialization.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/util/ChartSerialization.java
@@ -25,7 +25,9 @@ import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.vaadin.addon.charts.ChartOptions;
 import com.vaadin.addon.charts.model.AbstractConfigurationObject;
 import com.vaadin.addon.charts.model.serializers.AxisListSerializer;
@@ -35,10 +37,10 @@ import com.vaadin.addon.charts.model.serializers.DateSerializer;
 import com.vaadin.addon.charts.model.serializers.DefaultBeanSerializerModifier;
 import com.vaadin.addon.charts.model.serializers.GradientColorStopsSerializer;
 import com.vaadin.addon.charts.model.serializers.InstantSerializer;
-import com.vaadin.addon.charts.model.serializers.StringSerializer;
 import com.vaadin.addon.charts.model.serializers.PaneListSerializer;
 import com.vaadin.addon.charts.model.serializers.SolidColorSerializer;
 import com.vaadin.addon.charts.model.serializers.StopSerializer;
+import com.vaadin.addon.charts.model.serializers.StringSerializer;
 import com.vaadin.addon.charts.model.serializers.TimeUnitMultiplesSerializer;
 
 /**
@@ -87,7 +89,9 @@ public class ChartSerialization implements Serializable {
                 .registerModule(PaneListSerializer.getModule())
                 .registerModule(DateSerializer.getModule())
                 .registerModule(InstantSerializer.getModule())
-                .registerModule(StringSerializer.getModule());
+                .registerModule(StringSerializer.getModule())
+                .registerModule(new JavaTimeModule()).disable(
+                        SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS);
 
         // serializer modifier used when basic serializer isn't enough
         return mapper.setSerializerFactory(mapper.getSerializerFactory()


### PR DESCRIPTION
Updated version from https://github.com/vaadin/charts/pull/637
