### PR TITLE
chore: bump dependency versions, add JDK11 profile

### DIFF
--- a/addon/pom.xml
+++ b/addon/pom.xml
@@ -236,17 +236,17 @@
 		<dependency>
 			<groupId>javax.annotation</groupId>
 			<artifactId>javax.annotation-api</artifactId>
-			<version>1.3.1</version>
+			<version>1.3.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.15.2</version>
+			<version>2.16.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-jsr310</artifactId>
-			<version>2.15.2</version>
+			<version>2.16.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.vaadin</groupId>

--- a/examples/src/main/java/com/vaadin/addon/charts/examples/librarydata/Helmet.java
+++ b/examples/src/main/java/com/vaadin/addon/charts/examples/librarydata/Helmet.java
@@ -19,7 +19,7 @@ import java.util.Scanner;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
 /**
  * This class consumes the HelMet REST service, which provides data on books in
@@ -45,7 +45,7 @@ public class Helmet {
 
         ObjectMapper mapper = new ObjectMapper()
                 .setPropertyNamingStrategy(
-                        PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
+                        PropertyNamingStrategies.SNAKE_CASE)
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
                         false);
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,10 +32,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.organization>Vaadin Ltd</project.organization>
-        <vaadin.version>8.14.1</vaadin.version>
+        <vaadin.version>8.23.0</vaadin.version>
         <jetty.version>9.4.8.v20171121</jetty.version>
         <bundle.plugin.version>3.5.0</bundle.plugin.version>
-        <currentYear>2023</currentYear>
+        <currentYear>2024</currentYear>
+
+        <!-- Use Java 8 locale formats -->
+        <argLine>-Djava.locale.providers=COMPAT</argLine>
     </properties>
 
     <url>http://vaadin.com/charts</url>
@@ -224,7 +227,7 @@
                             </goals>
                             <configuration>
                                 <sourceFileExcludes>
-                                        <sourceFileExclude>**/module-info.java</sourceFileExclude>
+                                        <sourceFileExclude>**/module-inf3o.java</sourceFileExclude>
                                 </sourceFileExcludes>
                             </configuration>
                         </execution>
@@ -272,7 +275,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.7.0</version>
+                        <version>3.12.1</version>
                         <configuration>
                             <excludes>
                                 <exclude>module-info.java</exclude>
@@ -294,9 +297,32 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.7.0</version>
+                        <version>3.12.1</version>
                         <configuration>
                             <release>9</release>
+                            <encoding>UTF-8</encoding>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>jdk11</id>
+            <activation>
+                <jdk>[1.8,11)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.12.1</version>
+                        <configuration>
+                            <excludes>
+                                <exclude>module-info.java</exclude>
+                            </excludes>
+                            <release>8</release>
+                            <source>1.8</source>
+                            <target>1.8</target>
                             <encoding>UTF-8</encoding>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
Bump javax annotation api from 1.3.1 to 1.3.2
Bump jackson-databind from 2.15.2 to 2.16.1
Bump jackson-datatype-jsr310 from 2.15.2 to 2.16.1
Bump vaadin version from 8.14.1 to 8.23.0
Bump maven-compiler-plugin from 3.7.0. to 3.12.1