### PR TITLE
chore: Updates for modern Eclipse compatibility with Java 11

### DIFF
--- a/addon/pom.xml
+++ b/addon/pom.xml
@@ -183,6 +183,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>cobertura-maven-plugin</artifactId>
+				<version>2.7</version>
 				<configuration>
 					<instrumentation>
 						<ignores>

--- a/compatibility-addon/pom.xml
+++ b/compatibility-addon/pom.xml
@@ -180,6 +180,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>cobertura-maven-plugin</artifactId>
+				<version>2.7</version>
 				<configuration>
 					<instrumentation>
 						<ignores>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -34,27 +34,22 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-compatibility-server</artifactId>
-            <version>${vaadin.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-compatibility-client</artifactId>
-            <version>${vaadin.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-compatibility-shared</artifactId>
-            <version>${vaadin.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-server</artifactId>
-            <version>${vaadin.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-themes</artifactId>
-            <version>${vaadin.version}</version>
         </dependency>
 
         <dependency>
@@ -106,7 +101,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.3</version>
                 <configuration>
                     <packagingExcludes>**/gwt-unitCache/*,**/widgetsets/WEB-INF/**/*</packagingExcludes>
                 </configuration>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -54,17 +54,14 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-compatibility-server</artifactId>
-            <version>${vaadin.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-compatibility-client</artifactId>
-            <version>${vaadin.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-compatibility-shared</artifactId>
-            <version>${vaadin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.reflections</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,11 +29,13 @@
     </organization>
 
     <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.organization>Vaadin Ltd</project.organization>
         <vaadin.version>8.14.3</vaadin.version>
-        <jetty.version>9.4.8.v20171121</jetty.version>
+        <jetty.version>9.4.54.v20240208</jetty.version>
         <bundle.plugin.version>3.5.0</bundle.plugin.version>
         <currentYear>2024</currentYear>
 
@@ -147,7 +149,7 @@
 
                 <plugin>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.4.0</version>
                     <configuration>
                         <failOnMissingWebXml>false</failOnMissingWebXml>
                     </configuration>
@@ -208,6 +210,25 @@
                                         <ignore></ignore>
                                     </action>
                                 </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>
+                                            org.apache.felix
+                                        </groupId>
+                                        <artifactId>
+                                            maven-bundle-plugin
+                                        </artifactId>
+                                        <versionRange>
+                                            [${bundle.plugin.version},)
+                                        </versionRange>
+                                        <goals>
+                                            <goal>manifest</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
                             </pluginExecutions>
                         </lifecycleMappingMetadata>
                     </configuration>
@@ -229,6 +250,30 @@
                                 <sourceFileExcludes>
                                         <sourceFileExclude>**/module-info.java</sourceFileExclude>
                                 </sourceFileExcludes>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <!-- Enforce minimum Maven version -->
+                <plugin>
+                    <inherited>true</inherited>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.3.0</version>
+                    <executions>
+                        <execution>
+                            <id>enforce-maven-version</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <requireMavenVersion>
+                                        <version>3.6.2</version>
+                                    </requireMavenVersion>                
+                                </rules>
+                                <fail>true</fail>
                             </configuration>
                         </execution>
                     </executions>


### PR DESCRIPTION
- Update Jetty version
- Update maven-war-plugin version
- Add maven-bundle-plugin to lifecycle-mapping
- Remove overriding of managed dependency versions with the same versions
- Specify cobertura-maven-plugin version