### PR TITLE
fix: HighCharts 4.2.7 setData regression

### DIFF
--- a/addon/src/main/resources/com/vaadin/addon/charts/client/highcharts-workarounds.js
+++ b/addon/src/main/resources/com/vaadin/addon/charts/client/highcharts-workarounds.js
@@ -51,5 +51,31 @@
 
     return result;
   };
+  
+  Highcharts.Axis.prototype.updateNames = function() {
+    var axis = this;
+    if (this.names.length > 0) {
+      this.names.length = 0;
+      this.minRange = undefined;
+      Highcharts.each(this.series || [], function(series) {
+
+        // When adding a series, points are not yet generated
+        if (!series.points || series.isDirtyData) {
+          series.processData();
+          series.generatePoints();
+        }
+        Highcharts.each(series.points, function(point, i) {
+          var x;
+          if (point.options) {
+            x = axis.nameToX(point);
+            if (x !== point.x) {
+              point.x = x;
+              series.xData[i] = x;
+            }
+          }
+        });
+      });
+    }
+  };
 
 }(Highcharts));

--- a/examples/src/main/java/com/vaadin/addon/charts/examples/columnandbar/ColumnUpdateItemName.java
+++ b/examples/src/main/java/com/vaadin/addon/charts/examples/columnandbar/ColumnUpdateItemName.java
@@ -1,0 +1,62 @@
+/*
+ * Vaadin Charts Addon
+ *
+ * Copyright (C) 2012-2024 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.addon.charts.examples.columnandbar;
+
+import com.vaadin.addon.charts.Chart;
+import com.vaadin.addon.charts.examples.AbstractVaadinChartExample;
+import com.vaadin.addon.charts.examples.SkipFromDemo;
+import com.vaadin.addon.charts.model.AxisType;
+import com.vaadin.addon.charts.model.ChartType;
+import com.vaadin.addon.charts.model.Configuration;
+import com.vaadin.addon.charts.model.DataSeries;
+import com.vaadin.addon.charts.model.DataSeriesItem;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Component;
+
+@SuppressWarnings("serial")
+@SkipFromDemo
+public class ColumnUpdateItemName extends AbstractVaadinChartExample {
+
+    private DataSeriesItem item;
+    private DataSeries series;
+
+    @Override
+    public String getDescription() {
+        return "Basic column with one item that gets renamed via button click";
+    }
+
+    @Override
+    protected Component getChart() {
+        Chart chart = new Chart(ChartType.COLUMN);
+        chart.setId("column-update-item-name");
+        Configuration conf = chart.getConfiguration();
+        conf.getxAxis().setType(AxisType.CATEGORY);
+
+        item = new DataSeriesItem(0, 6);
+        item.setName("X");
+        series = new DataSeries(item);
+        conf.setSeries(series);
+
+        return chart;
+    }
+
+    @Override
+    protected void setup() {
+        super.setup();
+
+        Button button = new Button("update item name", e -> {
+            item.setName("Y");
+            series.update(item);
+        });
+        button.setId("update-button");
+        addComponent(button);
+    }
+}

--- a/integration-tests/src/test/java/com/vaadin/addon/charts/testbenchtests/ColumnUpdateItemNameTBTest.java
+++ b/integration-tests/src/test/java/com/vaadin/addon/charts/testbenchtests/ColumnUpdateItemNameTBTest.java
@@ -1,0 +1,62 @@
+/*
+ * Vaadin Charts Addon
+ *
+ * Copyright (C) 2012-2024 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.addon.charts.testbenchtests;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.addon.charts.examples.columnandbar.ColumnUpdateItemName;
+import com.vaadin.testbench.elements.ButtonElement;
+
+public class ColumnUpdateItemNameTBTest extends AbstractParallelTest {
+
+    @Test
+    public void test() throws IOException, AssertionError {
+        driver.get(getTestUrl());
+        waitForVaadin();
+
+        WebElement chart = findElement(By.id("column-update-item-name"));
+
+        assertEquals("Unexpected initial column name", "X",
+                getColumnLabel(chart));
+
+        $(ButtonElement.class).id("update-button").click();
+        waitForVaadin();
+
+        assertEquals("Unexpected updated column name", "Y",
+                getColumnLabel(chart));
+    }
+
+    private String getColumnLabel(WebElement chart) {
+        List<WebElement> xLabels = chart
+                .findElements(By.className("highcharts-xaxis-labels"));
+        assertEquals("Unexpect amount of columns", 1, xLabels.size());
+
+        WebElement xLabel = xLabels.get(0);
+        return xLabel.findElement(By.tagName("tspan")).getText();
+    }
+
+    @Override
+    protected String getTestViewName() {
+        return ColumnUpdateItemName.class.getSimpleName();
+    }
+
+    @Override
+    protected String getPackageName() {
+        return "columnandbar";
+    }
+}


### PR DESCRIPTION
Updating DataSeriesItem's name should not reset the column labels.

Based on the patch for
https://github.com/highcharts/highcharts/issues/5768 and
https://github.com/highcharts/highcharts/commit/6f37316e50b76c42d7e31fef17e9c0918fdfe959