### PR TITLE
fix: Sanitize all serialized strings. This is a backport from 4.x.

### DIFF
--- a/addon/src/main/java/com/vaadin/addon/charts/model/serializers/StringSerializer.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/model/serializers/StringSerializer.java
@@ -1,0 +1,76 @@
+/*
+ * Vaadin Charts Addon
+ *
+ * Copyright (C) 2012-2023 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.addon.charts.model.serializers;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.safety.Safelist;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+/**
+ * Serializes all {@link java.lang.String} objects that are not functions as
+ * sanitized Strings.
+ */
+public class StringSerializer extends JsonSerializer<String> {
+
+    public static Module getModule() {
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(String.class, new StringSerializer());
+
+        return module;
+    }
+
+    @Override
+    public void serialize(String value, JsonGenerator gen,
+            SerializerProvider serializers)
+            throws IOException, JsonProcessingException {
+        value = shouldSanitize(value, gen) ? sanitize(value) : value;
+        gen.writeString(value);
+    }
+
+    /**
+     * Functions (_fn_ prefixed properties) and null values should not be
+     * sanitized
+     */
+    private boolean shouldSanitize(String value, JsonGenerator gen) {
+        return value != null && gen.getOutputContext().inObject()
+                && !gen.getOutputContext().getCurrentName().startsWith("_fn_")
+                && isHtml(value);
+    }
+
+    private boolean isHtml(String html) {
+        Pattern htmlPattern = Pattern.compile(".*\\<[^>]+>.*", Pattern.DOTALL);
+        return htmlPattern.matcher(html).matches();        
+    }
+
+    /*
+     * Helper function for content sanitization, this preserves common
+     * formatting, but strips scripts. Workaround for:
+     * https://github.com/highcharts/highcharts/issues/13559 See also:
+     * SNYK-JS-HIGHCHARTS-571995Ï
+     */
+    private String sanitize(String html) {
+        Safelist safelist = Safelist.relaxed()
+                .addAttributes(":all", "style")
+                .addEnforcedAttribute("a", "rel", "nofollow");
+        String sanitized = Jsoup.clean(html, "", safelist, new Document.OutputSettings().prettyPrint(false));
+        return sanitized;
+    }
+}

--- a/addon/src/main/java/com/vaadin/addon/charts/util/ChartSerialization.java
+++ b/addon/src/main/java/com/vaadin/addon/charts/util/ChartSerialization.java
@@ -29,6 +29,7 @@ import com.vaadin.addon.charts.model.serializers.GradientColorStopsSerializer;
 import com.vaadin.addon.charts.model.serializers.PaneListSerializer;
 import com.vaadin.addon.charts.model.serializers.SolidColorSerializer;
 import com.vaadin.addon.charts.model.serializers.StopSerializer;
+import com.vaadin.addon.charts.model.serializers.StringSerializer;
 import com.vaadin.addon.charts.model.serializers.TimeUnitMultiplesSerializer;
 
 /**
@@ -67,7 +68,8 @@ public class ChartSerialization implements Serializable {
                 .registerModule(GradientColorStopsSerializer.getModule())
                 .registerModule(AxisListSerializer.getModule())
                 .registerModule(PaneListSerializer.getModule())
-                .registerModule(DateSerializer.getModule());
+                .registerModule(DateSerializer.getModule())
+                .registerModule(StringSerializer.getModule());
 
         // serializer modifier used when basic serializer isn't enough
         return mapper.setSerializerFactory(mapper.getSerializerFactory()

--- a/addon/src/test/java/com/vaadin/addon/charts/junittests/UnsafeHTMLJSONSerializationTest.java
+++ b/addon/src/test/java/com/vaadin/addon/charts/junittests/UnsafeHTMLJSONSerializationTest.java
@@ -1,0 +1,66 @@
+/*
+ * Vaadin Charts Addon
+ *
+ * Copyright (C) 2012-2023 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.addon.charts.junittests;
+
+import static com.vaadin.addon.charts.util.ChartSerialization.toJSON;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.vaadin.addon.charts.model.Configuration;
+import com.vaadin.addon.charts.model.Tooltip;
+
+public class UnsafeHTMLJSONSerializationTest {
+
+    @Test
+    public void configurationJSONSerialization_tablePreserved() {
+        Configuration conf = new Configuration();
+        Tooltip tooltip = new Tooltip();
+        tooltip.setUseHTML(true);
+        tooltip.setPointFormat("<table><tbody><tr><td>{series.name}</td></tr><tr><td>{point.y}</td></tr></tbody></table>");
+        conf.setTooltip(tooltip);
+            assertEquals(
+                "{\"tooltip\":{\"pointFormat\":\"<table><tbody><tr><td>{series.name}</td></tr><tr><td>{point.y}</td></tr></tbody></table>\",\"useHTML\":true},\"plotOptions\":{},\"series\":[],\"exporting\":{\"enabled\":false}}",
+                toJSON(conf));
+    }
+
+    @Test
+    public void configurationJSONSerialization_plainString_notTouched() {
+        Configuration conf = new Configuration();
+        conf.setTitle(
+                "This & that is this & that");
+            assertEquals(
+                "{\"title\":{\"text\":\"This & that is this & that\"},\"plotOptions\":{},\"series\":[],\"exporting\":{\"enabled\":false}}",
+                toJSON(conf));
+    }
+
+    @Test
+    public void configurationJSONSerialization_unsafeTitle_unsafeHTMLNotSerialized() {
+        Configuration conf = new Configuration();
+        conf.setTitle(
+                "1. JavaScript injected in plain href: <a href=\'#\";alert(\"XSS 1\");var fake=\"\'>Click here</a><br> 2. JavaScript injected as href=\"javascript:...\": <a href=\"javascript:alert(\'XSS 2\')\">Click here</a><br> Source: <a href=\"http://thebulletin.metapress.com/content/c4120650912x74k7/fulltext.pdf\">thebulletin.metapress.com</a>");
+
+        assertEquals(
+                "{\"title\":{\"text\":\"1. JavaScript injected in plain href: <a rel=\\\"nofollow\\\">Click here</a><br> 2. JavaScript injected as href=\\\"javascript:...\\\": <a rel=\\\"nofollow\\\">Click here</a><br> Source: <a href=\\\"http://thebulletin.metapress.com/content/c4120650912x74k7/fulltext.pdf\\\" rel=\\\"nofollow\\\">thebulletin.metapress.com</a>\"},\"plotOptions\":{},\"series\":[],\"exporting\":{\"enabled\":false}}",
+                toJSON(conf));
+    }
+
+    @Test
+    public void configurationJSONSerialization_unsafeSubTitle_unsafeHTMLNotSerialized() {
+        Configuration conf = new Configuration();
+        conf.setSubTitle(
+                "1. JavaScript injected in plain href: <a href=\'#\";alert(\"XSS 1\");var fake=\"\'>Click here</a><br> 2. JavaScript injected as href=\"javascript:...\": <a href=\"javascript:alert(\'XSS 2\')\">Click here</a><br> Source: <a href=\"http://thebulletin.metapress.com/content/c4120650912x74k7/fulltext.pdf\">thebulletin.metapress.com</a>");
+        assertEquals(
+                "{\"subtitle\":{\"text\":\"1. JavaScript injected in plain href: <a rel=\\\"nofollow\\\">Click here</a><br> 2. JavaScript injected as href=\\\"javascript:...\\\": <a rel=\\\"nofollow\\\">Click here</a><br> Source: <a href=\\\"http://thebulletin.metapress.com/content/c4120650912x74k7/fulltext.pdf\\\" rel=\\\"nofollow\\\">thebulletin.metapress.com</a>\"},\"plotOptions\":{},\"series\":[],\"exporting\":{\"enabled\":false}}",
+                toJSON(conf));
+    }
+
+}


### PR DESCRIPTION
Backport of commits [af1accec2b879c4755c8e5ae181a013edf0b4c08](https://github.com/vaadin/charts/commit/af1accec2b879c4755c8e5ae181a013edf0b4c08) and [141d83ddb22885cee7e2b59c1c17ea6b7a4f19cf](https://github.com/vaadin/charts/commit/141d83ddb22885cee7e2b59c1c17ea6b7a4f19cf)