### PR TITLE
fix: Fix vaadin-server scope in model

### DIFF
--- a/model/pom.xml
+++ b/model/pom.xml
@@ -64,6 +64,7 @@
 			<groupId>com.vaadin</groupId>
 			<artifactId>vaadin-server</artifactId>
 			<version>${vaadin.version}</version>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
The scope was correct in the addon module, but wrong in the model module. This will conflict when used with vaadin-server-mpr-jakarta.