### PR TITLE
chore: Update POMs to compile on current tooling (3.3)

### DIFF
--- a/book-examples/pom.xml
+++ b/book-examples/pom.xml
@@ -3,13 +3,13 @@
          xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.vaadin.addon</groupId>
-    <artifactId>book-examples</artifactId>
     <parent>
         <groupId>com.vaadin.addon</groupId>
         <artifactId>vaadin-charts-parent</artifactId>
         <version>3.3-SNAPSHOT</version>
     </parent>
+    <artifactId>book-examples</artifactId>
+    
     <dependencies>
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -38,16 +38,6 @@
         </dependency>
     </dependencies>
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
-    </plugins>
         <resources>
             <resource>
                 <directory>src/main/java</directory>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -84,10 +84,27 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>5.7.0</version>
+            <version>6.1.0</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.docker-java</groupId>
+                    <artifactId>docker-java-transport-httpclient5</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.java.dev.jna</groupId>
+                    <artifactId>jna</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.java.dev.jna</groupId>
+                    <artifactId>jna-platform</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
-
 
         <!-- Required for some reflection issues -->
         <dependency>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -79,9 +79,22 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>22.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.bonigarcia</groupId>
+            <artifactId>webdrivermanager</artifactId>
+            <version>5.7.0</version>
+            <scope>test</scope>
         </dependency>
 
+
+        <!-- Required for some reflection issues -->
+        <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>3.30.2-GA</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -13,7 +13,6 @@
 	<packaging>jar</packaging>
 	<name>Vaadin Charts Model</name>
 	<inceptionYear>2012</inceptionYear>
-	<version>3.3-SNAPSHOT</version>
 
 	<properties>
 		<license.projectName>Vaadin Charts</license.projectName>
@@ -63,7 +62,6 @@
 		<dependency>
 			<groupId>com.vaadin</groupId>
 			<artifactId>vaadin-server</artifactId>
-			<version>${vaadin.version}</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,9 @@
         <vaadin.version>7.7.42</vaadin.version>
         <jetty.version>9.4.8.v20171121</jetty.version>
         <currentYear>2024</currentYear>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.release>7</maven.compiler.release>
     </properties>
 
     <url>https://vaadin.com/charts</url>
@@ -53,9 +56,9 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>vaadin-snapshots</id>
+            <id>vaadin-prereleases</id>
             <name>Vaadin snapshot repository</name>
-            <url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
+            <url>https://maven.vaadin.com/vaadin-prereleases</url>
         </snapshotRepository>
         <repository>
             <id>vaadin-addons</id>
@@ -120,38 +123,6 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.3</version>
-                    <configuration>
-                        <source>1.6</source>
-                        <target>1.6</target>
-                        <encoding>UTF-8</encoding>
-                    </configuration>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.10</version>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-war-plugin</artifactId>
-                    <version>2.4</version>
-                    <configuration>
-                        <failOnMissingWebXml>false</failOnMissingWebXml>
-                    </configuration>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.7</version>
-                    <configuration>
-                        <!-- enable deployment by default, skip when needed -->
-                        <skip>false</skip>
-                    </configuration>
-                </plugin>
-
-                <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>2.7</version>
                     <configuration>
@@ -170,6 +141,15 @@
                     <artifactId>jetty-maven-plugin</artifactId>
                     <version>${jetty.version}</version>
                 </plugin>
+                
+                <plugin>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <version>3.4.0</version>
+                    <configuration>
+                        <failOnMissingWebXml>false</failOnMissingWebXml>
+                    </configuration>
+                </plugin>
+
 
                 <!--This plugin's configuration is used to store Eclipse
                     m2e settings only. It has no influence on the Maven build itself. -->


### PR DESCRIPTION
The POMs of the project need to be updated to compile on current JDKs and against current Vaadin 7 versions.
Has the side effect of updating the target JDK/JRE version to at least 1.7.x.